### PR TITLE
Fix ztest build on FreeBSD

### DIFF
--- a/ztest/shell_freebsd.go
+++ b/ztest/shell_freebsd.go
@@ -1,4 +1,4 @@
-//go:build unix && !freebsd
+//go:build freebsd
 
 package ztest
 
@@ -25,7 +25,7 @@ func Mknod(t *testing.T, dev int, path ...string) {
 	if len(path) < 1 {
 		t.Fatalf("ztest.Mknod: path must have at least one element: %s", path)
 	}
-	err := syscall.Mknod(join(path...), 0o644, dev)
+	err := syscall.Mknod(join(path...), 0o644, uint64(dev))
 	if err != nil {
 		t.Fatalf("ztest.Mknod(%d, %q): %s", dev, join(path...), err)
 	}


### PR DESCRIPTION
This fixes the build on FreeBSD, which wasn't working because syscall.Mknod takes dev as a uint64 on FreeBSD.

I confirmed the project builds for the following GOOS:

    linux, freebsd, openbsd, darwin, windows

Would be nice if there was a way to use build tags inline in a function, but there isn't so I duplicated the file.